### PR TITLE
lat and lng are reversed

### DIFF
--- a/common/models/location.js
+++ b/common/models/location.js
@@ -38,7 +38,7 @@ module.exports = function(RentalLocation) {
     lookupGeo(loc.street, loc.city, loc.state,
       function(err, result) {
         if (result && result[0]) {
-          loc.geo = result[0].lng + ',' + result[0].lat;
+          loc.geo = result[0];
           next();
         } else {
           next(new Error('could not find location'));


### PR DESCRIPTION
they are parsed in the reverse order at https://github.com/strongloop/loopback-datasource-juggler/blob/master/lib/geo.js#L141.

Instead of encoding it into a string better directly pass the object.