### PR TITLE
add legacyExplorer: true so load script works

### DIFF
--- a/server/config.json
+++ b/server/config.json
@@ -1,5 +1,5 @@
 {
-  "legacyExplorer": false,
+  "legacyExplorer": true,
   "restApiRoot": "/api",
   "host": "0.0.0.0",
   "port": 3000,


### PR DESCRIPTION
Without this change the load script `bin/create-load.js` errors out with:
```
/Users/rand/StrongLoop/loopback-example-app/bin/create-load.js:87
  return routes.filter(function (route) {
                ^
TypeError: undefined is not a function
...
```